### PR TITLE
[Do not merge] CaseStack -> SupplyPike rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version": "0.2.22",
     "repository": {
         "type": "git",
-        "url": "git://github.com/casestack/oi.select.git"
+        "url": "git://github.com/supplypike/oi.select.git"
     },
     "devDependencies": {
         "gulp": "3.9.1",


### PR DESCRIPTION
**Do not merge until the GitHub Organization has been renamed to SupplyPike**

This PR should only rename references to `github.com/casestack` (or other derivatives, like `github.com:casestack`) to their equivelant `github.com/supplypike` URL. 
CaseStack licenses were also removed if a CaseStack-specific license existed.

NPM packages using the `@casestack` user will be migrated separately.

There might be some issues after the rename occurs, like: 
* CI or CD might have to be re-enabled, like: 
    * Travis
    * Shippable
*OAuth Apps
    * Pivotal Tracker?
    * Review Table?

---

Once renamed, developers will need to update their remote URL for their locally cloned version:
```bash

# HTTPS
git remote set-url origin https://github.com/supplypike/oi.select.git

# or SSH
git remote set-url origin git@github.com:supplypike/oi.select.git 
```